### PR TITLE
Fixed typo in Calling C and Python ##Matplotlib

### DIFF
--- a/container/interactive/IJulia/tutorial/Calling C and Python.ipynb
+++ b/container/interactive/IJulia/tutorial/Calling C and Python.ipynb
@@ -932,7 +932,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get Matplotlib working in IJulia, we had to do a bit more work, similar to what IPython had to do to get its `pylab` option working.   For GUI windows, we had to implement the GUI event loop for the Python GUI toolkit(s) (PyQt, Gtk, wx) in Julia.  For inline plots, we had to monkey-patch Matplotlib to intercept its drawing commands queue the figure for rendering as an image to be sent to the front-end.  All of this is done by the `PyPlot` Julia module:"
+    "To get Matplotlib working in IJulia, we had to do a bit more work, similar to what IPython had to do to get its `pylab` option working.   For GUI windows, we had to implement the GUI event loop for the Python GUI toolkit(s) (PyQt, Gtk, wx) in Julia.  For inline plots, we had to monkey-patch Matplotlib to intercept its drawing commands and queue the figure for rendering as an image to be sent to the front-end.  All of this is done by the `PyPlot` Julia module:"
    ]
   },
   {


### PR DESCRIPTION
 There is a typo in the tutorial file, Calling C and Python, section ## Calling Matplotlib:
    " ... we had to monkey-patch Matplotlib to intercept its drawing commands [] queue the figure for rendering ... "

I'm not sure if it should be "and", "to", "in order to" or something else. I'd love feedback from a reviewer! :)
